### PR TITLE
feat: Реализовано удаление пользователей и фильмов

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build/
 
 *.db
 db/*
+.DS_Store

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -1,5 +1,8 @@
 package ru.yandex.practicum.filmorate.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,4 +61,14 @@ public class FilmController {
         return filmService.getFilmOrThrow(id);
     }
 
+    @DeleteMapping("/{filmId}")
+    public ResponseEntity<Void> deleteById(@PathVariable Long filmId) {
+        log.info("Получен запрос DELETE /films/{}", filmId);
+        try {
+            filmService.deleteById(filmId);
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (NotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
@@ -1,5 +1,8 @@
 package ru.yandex.practicum.filmorate.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -55,5 +58,16 @@ public class UserController {
     @GetMapping("/{id}/friends/common/{otherId}")
     public Collection<User> getCommonFriends(@PathVariable Long id, @PathVariable Long otherId) {
         return userService.getCommonFriends(id, otherId);
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deleteById(@PathVariable Long userId) {
+        log.info("Получен запрос DELETE /users/{}", userId);
+        try {
+            userService.deleteById(userId);
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (NotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -55,4 +55,10 @@ public class FilmService {
     public Film getFilmOrThrow(Long id) {
         return filmStorage.findById(id).orElseThrow(() -> new NotFoundException("Фильм c " + id + " не найден"));
     }
+
+    public void deleteById(Long filmId) {
+        getFilmOrThrow(filmId);
+        filmStorage.deleteById(filmId);
+        log.info("Фильм с id={} удален", filmId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
@@ -63,5 +63,9 @@ public class UserService {
         return userStorage.getCommonFriends(userId, otherId);
     }
 
-
+    public void deleteById(Long userId) {
+        getUserOrThrow(userId);
+        userStorage.deleteById(userId);
+        log.info("Пользователь с id={} удален", userId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -166,4 +166,10 @@ public class FilmDbStorage implements FilmStorage {
     public List<Film> getPopularFilms(int count) {
         return jdbcTemplate.query(FIND_FILM_COUNT_QUERY, new FilmMapper(), count);
     }
+
+    @Override
+    public void deleteById(Long filmId) {
+        String sql = "DELETE FROM films WHERE film_id = ?";
+        jdbcTemplate.update(sql, filmId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -21,4 +21,6 @@ public interface FilmStorage {
     List<Film> getPopularFilms(int count);
 
     void addLike(Long filmId, Long userId);
+
+    void deleteById(Long filmId);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
@@ -52,6 +52,15 @@ public class InMemoryFilmStorage implements FilmStorage {
     }
 
     @Override
+    public void deleteById(Long filmId) {
+        if (films.remove(filmId) != null) {
+            log.info("Фильм с id={} удален из InMemory хранилища", filmId);
+        } else {
+            log.warn("Попытка удалить несуществующий фильм с id={} из InMemory хранилища", filmId);
+        }
+    }
+
+    @Override
     public void removeLike(Long filmId, Long userId) {
 
     }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
@@ -67,6 +67,15 @@ public class InMemoryUserStorage implements UserStorage {
     }
 
     @Override
+    public void deleteById(Long userId) {
+        if (users.remove(userId) != null) {
+            log.info("Пользователь с id={} удален из InMemory хранилища", userId);
+        } else {
+            log.warn("Попытка удалить несуществующего пользователя с id={} из InMemory хранилища", userId);
+        }
+    }
+
+    @Override
     public void addFriend(Long userId, Long friendId) {
 
     }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserDbStorage.java
@@ -138,4 +138,10 @@ public class UserDbStorage implements UserStorage {
     public List<User> getCommonFriends(Long userId, Long otherId) {
         return jdbcTemplate.query(FIND_COMMON_FRIEND_QUERY, new UserMapper(), userId, otherId);
     }
+
+    @Override
+    public void deleteById(Long userId) {
+        String sql = "DELETE FROM users WHERE user_id = ?";
+        jdbcTemplate.update(sql, userId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserStorage.java
@@ -23,4 +23,6 @@ public interface UserStorage {
     List<User> getFriends(Long userId);
 
     List<User> getCommonFriends(Long userId, Long otherId);
+
+    void deleteById(Long userId);
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS films_genres (
                                             film_id BIGINT NOT NULL,
                                             genre_id BIGINT NOT NULL,
                                             PRIMARY KEY (film_id, genre_id),
-                                            FOREIGN KEY(film_id) REFERENCES films(film_id),
+                                            FOREIGN KEY(film_id) REFERENCES films(film_id) ON DELETE CASCADE,
                                             FOREIGN KEY(genre_id) REFERENCES genres(genre_id)
 );
 
@@ -38,15 +38,15 @@ CREATE TABLE IF NOT EXISTS friends (
                                        friend_id BIGINT NOT NULL,
                                        isConfirm bool NOT NULL DEFAULT false,
                                        PRIMARY KEY (user_id, friend_id),
-                                       FOREIGN KEY(user_id) REFERENCES users(user_id),
-                                       FOREIGN KEY(friend_id) REFERENCES users(user_id)
+                                       FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+                                       FOREIGN KEY(friend_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS likes (
                                      user_id BIGINT NOT NULL,
                                      film_id BIGINT NOT NULL,
                                      PRIMARY KEY (user_id, film_id),
-                                     FOREIGN KEY(film_id) REFERENCES films(film_id),
-                                     FOREIGN KEY(user_id) REFERENCES users(user_id)
+                                     FOREIGN KEY(film_id) REFERENCES films(film_id) ON DELETE CASCADE,
+                                     FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
 
 );


### PR DESCRIPTION
Реализована функциональность удаления пользователей и фильмов по ID (DELETE /users/{id} и DELETE /films/{id}).

В schema.sql добавлены правила ON DELETE CASCADE для обеспечения целостности данных.
API корректно возвращает 200 OK при успешном удалении и 404 Not Found при попытке удалить несуществующую сущность.

Но снова падает тест в Postman... 
Delete user падает, потому что его pre-request скрипт создает нового пользователя, а сам тест ожидает 404, хотя по логике должен получить 200 OK. Проблема находится в самой коллекции тестов, а не в коде (надеюсь на это). Вопрос по этому поводу уже задан наставнику в пачке. Так что ждём. Если я ошибаюсь, то исправлю ветку. 