### PR TITLE
fix: Исправление ошибок в логике для прохождения тестов

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/EventService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/EventService.java
@@ -1,6 +1,7 @@
 package ru.yandex.practicum.filmorate.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.model.event.Event;
 import ru.yandex.practicum.filmorate.storage.event.EventStorage;
@@ -11,12 +12,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EventService {
     private final EventStorage eventStorage;
+    @Lazy
+    private final UserService userService;
 
     public void addEvent(Event event) {
         eventStorage.addEvent(event);
     }
 
     public List<Event> getFeedForUser(Long userId) {
+        userService.getUserOrThrow(userId);
         return eventStorage.getFeedForUser(userId);
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -24,8 +24,7 @@ public class FilmService {
     private final DirectorService directorService;
 
     @Autowired
-    public FilmService(@Qualifier("filmDbStorage") FilmStorage filmStorage,
-                       UserService userService,
+    public FilmService(@Qualifier("filmDbStorage") FilmStorage filmStorage, UserService userService,
                        EventService eventService,
                        DirectorService directorService) {
         this.filmStorage = filmStorage;
@@ -64,6 +63,13 @@ public class FilmService {
     public void removeLike(Long filmId, Long userId) {
         getFilmOrThrow(filmId);
         userService.getUserOrThrow(userId);
+
+        if (!filmStorage.hasLike(filmId, userId)) {
+            throw new NotFoundException(
+                    String.format("Лайк от пользователя id=%d для фильма id=%d не найден.", userId, filmId)
+            );
+        }
+
         filmStorage.removeLike(filmId, userId);
 
         Event event = Event.builder()

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -46,4 +46,6 @@ public interface FilmStorage {
     List<Film> searchFilms(String query, List<String> searchBy);
 
     List<Film> getFilmsByDirector(Long directorId, String sortBy);
+
+    boolean hasLike(Long filmId, Long userId);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
@@ -154,4 +154,14 @@ public class InMemoryFilmStorage implements FilmStorage {
 
         return filmsByDirector;
     }
+
+    @Override
+    public boolean hasLike(Long filmId, Long userId) {
+        // Простая реализация для InMemory-хранилища
+        Film film = films.get(filmId);
+        if (film == null) {
+            return false;
+        }
+        return film.getLikes().contains(userId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/review/ReviewDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/review/ReviewDbStorage.java
@@ -189,7 +189,10 @@ public class ReviewDbStorage implements ReviewStorage {
     @Override
     public void removeLike(Long reviewId, Long userId) {
         String sql = "DELETE FROM review_likes WHERE review_id = ? AND user_id = ?";
-        jdbcTemplate.update(sql, reviewId, userId);
+        int rowsAffected = jdbcTemplate.update(sql, reviewId, userId);
+        if (rowsAffected == 0) {
+            //throw new NotFoundException("Лайк для отзыва не найден");
+        }
     }
 
     /**

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
@@ -100,4 +100,13 @@ public class InMemoryUserStorage implements UserStorage {
     public Collection<Film> getRecommendations(Long id) {
         return List.of();
     }
+
+    @Override
+    public boolean isFriend(Long userId, Long friendId) {
+        User user = users.get(userId);
+        if (user == null) {
+            return false;
+        }
+        return user.getFriends().contains(friendId);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserStorage.java
@@ -28,4 +28,6 @@ public interface UserStorage {
     void deleteById(Long userId);
 
     Collection<Film> getRecommendations(Long id);
+
+    boolean isFriend(Long userId, Long friendId);
 }


### PR DESCRIPTION
Основные изменения:

1. Исправлено обновление фильмов (FilmDbStorage.update). При обновлении фильма с пустым списком жанров/режиссеров ("genres": []), старые значения не удалялись из базы. Тесты ожидали пустой список, а получали старый.
Теперь всегда полностью перезаписывает списки жанров и режиссеров, корректно обрабатывая пустые массивы.

2. Добавлены проверки на существование перед удалением (FilmService, UserService). 
Потому что при попытке удалить несуществующий лайк или дружбу (DELETE /films/1/like/99 или DELETE /users/1/friends/99) сервер возвращал 200 OK вместо ожидаемого 404 Not Found. В сервисный слой добавлены предварительные проверки. Теперь, если лайка или дружбы не существует, выбрасывается NotFoundException, что приводит к ответу 404.

3. Исправлена логика получения данных (FilmDbStorage, EventService). Эндпоинты, возвращающие списки фильмов (/films/popular, /films/common и др.), не подгружали связанные данные (лайки, жанры, режиссеры). Тесты падали, так как получали неполные объекты. Добавлены вспомогательные методы для загрузки лайков, жанров и режиссеров. 

4. Добавлена проверка на существование пользователя в EventService при запросе ленты (/users/{id}/feed), чтобы возвращать 404 для несуществующих пользователей.

5. Убрала циклическую зависимость между UserService и EventService с помощью аннотации @Lazy (костыль, зато работает).